### PR TITLE
uses mysql-net (MIT MySqlConnector) package

### DIFF
--- a/Extension/MySql.cs
+++ b/Extension/MySql.cs
@@ -1290,7 +1290,7 @@ namespace PHP.Library.Data
         {
             PhpMyDbResult result = PhpMyDbResult.ValidResult(resultHandle);
             if (result == null) return null;
-
+            
             ColumnFlags flags = result.GetFieldFlags(fieldIndex);
             string type_name = result.GetPhpFieldType(fieldIndex);
 
@@ -1377,30 +1377,62 @@ namespace PHP.Library.Data
 
             Debug.Assert(result.GetRowCustomData() != null);
 
-            string php_type = result.GetPhpFieldType(fieldIndex);
-            PhpMyDbResult.FieldCustomData data = ((PhpMyDbResult.FieldCustomData[])result.GetRowCustomData())[fieldIndex];
-            ColumnFlags flags = data.Flags;//result.GetFieldFlags(fieldIndex);
+            var col = result.GetColumnSchema(fieldIndex);
+            var php_type = result.GetPhpFieldType(fieldIndex);
+
+            //PhpMyDbResult.FieldCustomData data = ((PhpMyDbResult.FieldCustomData[])result.GetRowCustomData())[fieldIndex];
+            //ColumnFlags flags = data.Flags;//result.GetFieldFlags(fieldIndex);
+
+            //name - column name
+            //table - name of the table the column belongs to, which is the alias name if one is defined
+            //max_length - maximum length of the column
+            //not_null - 1 if the column cannot be NULL
+            //primary_key - 1 if the column is a primary key
+            //unique_key - 1 if the column is a unique key
+            //multiple_key - 1 if the column is a non - unique key
+            //numeric - 1 if the column is numeric
+            //blob - 1 if the column is a BLOB
+            //type - the type of the column
+            //unsigned - 1 if the column is unsigned
+            //zerofill - 1 if the column is zero - filled
 
             // create an array of runtime fields with specified capacity:
-            var objFields = new PhpArray(13);
+            var objFields = new PhpArray(16)
+            {
+                { "name", col.ColumnName },
+                //{ "orgname", col.BaseColumnName },
+                { "table", col.BaseTableName ?? string.Empty },
+                //{ "def", "" }, // undocumented
+                //{ "db", col.BaseSchemaName },
+                //{ "catalog", col.BaseCatalogName },
+                //{ "max_length", /*result.GetFieldLength(fieldIndex)*/data.ColumnSize },
+                //{ "length", col.ColumnSize.GetValueOrDefault() },
+                { "not_null", col.AllowDBNull.GetValueOrDefault() == false },
+                { "primary_key", col.IsKey == true ? 1 : 0 },
+                //{ "multiple_key", ((flags & ColumnFlags.MULTIPLE_KEY) != 0) /*((bool)info["IsMultipleKey"])*/ ? 1 : 0 },
+                { "unique_key", col.IsUnique.GetValueOrDefault() ? 1 : 0 },
+                { "numeric", /*col.IsNumeric()*/col.IsNumeric() ? 1 : 0 },
+                { "blob", col.IsBlob() ? 1 : 0 },
+                { "type", php_type },
+                { "unsigned", col.IsUnsigned() ? 1 : 0 }, // ((flags & ColumnFlags.UNSIGNED) != 0) /*((bool)info["IsUnsigned"])*/ ? 1 : 0 },
+                //{ "zerofill", ((flags & ColumnFlags.ZERO_FILL) != 0) /*((bool)info["ZeroFill"])*/ ? 1 : 0 },
+            };
 
-            // add fields into the hastable directly:
-            // no duplicity check, since array is already valid
-            objFields.Add("name", result.GetFieldName(fieldIndex));
-            objFields.Add("table", (/*info["BaseTableName"] as string*/data.RealTableName) ?? string.Empty);
-            objFields.Add("def", ""); // TODO
-            objFields.Add("max_length", /*result.GetFieldLength(fieldIndex)*/data.ColumnSize);
+            //objFields.Add("name", col.ColumnName);
+            //objFields.Add("table", (/*info["BaseTableName"] as string*/data.RealTableName) ?? string.Empty);
+            //objFields.Add("def", ""); // TODO
+            //objFields.Add("max_length", /*result.GetFieldLength(fieldIndex)*/data.ColumnSize);
 
-            objFields.Add("not_null", ((flags & ColumnFlags.NOT_NULL) != 0) /*(!(bool)info["AllowDBNull"])*/ ? 1 : 0);
-            objFields.Add("primary_key", ((flags & ColumnFlags.PRIMARY_KEY) != 0) /*((bool)info["IsKey"])*/ ? 1 : 0);
-            objFields.Add("multiple_key", ((flags & ColumnFlags.MULTIPLE_KEY) != 0) /*((bool)info["IsMultipleKey"])*/ ? 1 : 0);
-            objFields.Add("unique_key", ((flags & ColumnFlags.UNIQUE_KEY) != 0) /*((bool)info["IsUnique"])*/ ? 1 : 0);
-            objFields.Add("numeric", result.IsNumericType(php_type) ? 1 : 0);
-            objFields.Add("blob", ((flags & ColumnFlags.BLOB) != 0) /*((bool)info["IsBlob"])*/ ? 1 : 0);
+            //objFields.Add("not_null", ((flags & ColumnFlags.NOT_NULL) != 0) /*(!(bool)info["AllowDBNull"])*/ ? 1 : 0);
+            //objFields.Add("primary_key", ((flags & ColumnFlags.PRIMARY_KEY) != 0) /*((bool)info["IsKey"])*/ ? 1 : 0);
+            //objFields.Add("multiple_key", ((flags & ColumnFlags.MULTIPLE_KEY) != 0) /*((bool)info["IsMultipleKey"])*/ ? 1 : 0);
+            //objFields.Add("unique_key", ((flags & ColumnFlags.UNIQUE_KEY) != 0) /*((bool)info["IsUnique"])*/ ? 1 : 0);
+            //objFields.Add("numeric", result.IsNumericType(php_type) ? 1 : 0);
+            //objFields.Add("blob", ((flags & ColumnFlags.BLOB) != 0) /*((bool)info["IsBlob"])*/ ? 1 : 0);
 
-            objFields.Add("type", php_type);
-            objFields.Add("unsigned", ((flags & ColumnFlags.UNSIGNED) != 0) /*((bool)info["IsUnsigned"])*/ ? 1 : 0);
-            objFields.Add("zerofill", ((flags & ColumnFlags.ZERO_FILL) != 0) /*((bool)info["ZeroFill"])*/ ? 1 : 0);
+            //objFields.Add("type", php_type);
+            //objFields.Add("unsigned", ((flags & ColumnFlags.UNSIGNED) != 0) /*((bool)info["IsUnsigned"])*/ ? 1 : 0);
+            //objFields.Add("zerofill", ((flags & ColumnFlags.ZERO_FILL) != 0) /*((bool)info["ZeroFill"])*/ ? 1 : 0);
 
             // create new stdClass with runtime fields initialized above:
             return new stdClass()

--- a/Extension/MySql.cs
+++ b/Extension/MySql.cs
@@ -1293,51 +1293,54 @@ namespace PHP.Library.Data
             PhpMyDbResult result = PhpMyDbResult.ValidResult(resultHandle);
             if (result == null) return null;
 
-            ColumnFlags flags = result.GetFieldFlags(fieldIndex);
-            string type_name = result.GetPhpFieldType(fieldIndex);
+            var col = result.GetColumnSchema(fieldIndex);
+            //ColumnFlags flags = result.GetFieldFlags(fieldIndex);
+            //string type_name = result.GetPhpFieldType(fieldIndex);
 
             StringBuilder str_fields = new StringBuilder();
 
-            if ((flags & ColumnFlags.NOT_NULL) != 0)
-                str_fields.Append("not_null ");
+            var flags = new List<string>(16);
 
-            if ((flags & ColumnFlags.PRIMARY_KEY) != 0)
-                str_fields.Append("primary_key ");
+            if (col.AllowDBNull == false)
+                flags.Add("not_null");
 
-            if ((flags & ColumnFlags.UNIQUE_KEY) != 0)
-                str_fields.Append("unique_key ");
+            if (col.IsKey == true)
+                flags.Add("primary_key");
 
-            if ((flags & ColumnFlags.MULTIPLE_KEY) != 0)
-                str_fields.Append("multiple_key ");
+            if (col.IsUnique == true)
+                flags.Add("unique_key");
 
-            if ((flags & ColumnFlags.BLOB) != 0)
-                str_fields.Append("blob ");
+            //if ((flags & ColumnFlags.MULTIPLE_KEY) != 0)
+            //    flags.Add("multiple_key");
 
-            if ((flags & ColumnFlags.UNSIGNED) != 0)
-                str_fields.Append("unsigned ");
+            if (col.IsBlob())
+                flags.Add("blob");
 
-            if ((flags & ColumnFlags.ZERO_FILL) != 0)
-                str_fields.Append("zerofill ");
+            if (col.IsUnsigned())
+                flags.Add("unsigned");
 
-            if ((flags & ColumnFlags.BINARY) != 0)
-                str_fields.Append("binary ");
+            //if ((flags & ColumnFlags.ZERO_FILL) != 0)
+            //    flags.Add("zerofill");
 
-            if ((flags & ColumnFlags.ENUM) != 0)
-                str_fields.Append("enum ");
+            if (col.ProviderType == MySqlDbType.Binary || col.ProviderType == MySqlDbType.VarBinary)
+                flags.Add("binary");
 
-            if ((flags & ColumnFlags.SET) != 0)
-                str_fields.Append("set ");
+            if (col.ProviderType == MySqlDbType.Enum)
+                flags.Add("enum");
 
-            if ((flags & ColumnFlags.AUTO_INCREMENT) != 0)
-                str_fields.Append("auto_increment ");
+            if (col.ProviderType == MySqlDbType.Set)
+                flags.Add("set");
 
-            if ((flags & ColumnFlags.TIMESTAMP) != 0)
-                str_fields.Append("timestamp ");
+            if (col.IsAutoIncrement.GetValueOrDefault())
+                flags.Add("auto_increment");
+
+            if (col.ProviderType == MySqlDbType.Timestamp)
+                flags.Add("timestamp");
 
             if (str_fields.Length > 0)
                 str_fields.Length = str_fields.Length - 1;
 
-            return str_fields.ToString();
+            return string.Join(" ", flags);
         }
 
         /// <summary>

--- a/Extension/MySql.cs
+++ b/Extension/MySql.cs
@@ -228,8 +228,10 @@ namespace PHP.Library.Data
             bool success;
             PhpMyDbConnection connection = (PhpMyDbConnection)manager.OpenConnection(connectionString, false, MySqlConfiguration.Global.MaxConnections, out success);
 
-            if (!success) {
-                if (connection != null) {
+            if (!success)
+            {
+                if (connection != null)
+                {
                     UpdateConnectErrorInfo(connection);
                     connection = null;
                 }
@@ -1290,7 +1292,7 @@ namespace PHP.Library.Data
         {
             PhpMyDbResult result = PhpMyDbResult.ValidResult(resultHandle);
             if (result == null) return null;
-            
+
             ColumnFlags flags = result.GetFieldFlags(fieldIndex);
             string type_name = result.GetPhpFieldType(fieldIndex);
 

--- a/Extension/MySql.csproj
+++ b/Extension/MySql.csproj
@@ -33,7 +33,7 @@
     <SccProvider>SAK</SccProvider>
     <OldToolsVersion>3.5</OldToolsVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -180,6 +180,9 @@
   <ItemGroup>
     <PackageReference Include="MySqlConnector">
       <Version>0.68.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Data.Common">
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="System.Memory">
       <Version>4.5.4</Version>

--- a/Extension/MySql.csproj
+++ b/Extension/MySql.csproj
@@ -33,7 +33,7 @@
     <SccProvider>SAK</SccProvider>
     <OldToolsVersion>3.5</OldToolsVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -98,43 +98,28 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MySqlConnector, Version=0.66.0.0, Culture=neutral, PublicKeyToken=d33d3e53aa5f8c92, processorArchitecture=MSIL">
-      <HintPath>..\packages\MySqlConnector.0.66.0\lib\net461\MySqlConnector.dll</HintPath>
-    </Reference>
     <Reference Include="PhpNetClassLibrary, Version=4.0.0.0, Culture=neutral, PublicKeyToken=4af37afe3cde05fb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\snap\ExternalAssemblies\Phalanger\PhpNetClassLibrary.dll</HintPath>
+      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetClassLibrary.dll</HintPath>
     </Reference>
     <Reference Include="PhpNetCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0a8e8c4c76728c71, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\snap\ExternalAssemblies\Phalanger\PhpNetCore.dll</HintPath>
+      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetCore.dll</HintPath>
     </Reference>
     <Reference Include="PhpNetCore.Parsers, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0a8e8c4c76728c71, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\snap\ExternalAssemblies\Phalanger\PhpNetCore.Parsers.dll</HintPath>
+      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetCore.Parsers.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>
     </Reference>
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
-    </Reference>
     <Reference Include="System.Data">
       <Name>System.Data</Name>
     </Reference>
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    <Reference Include="System.Data.Common, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.Common.4.3.0\lib\net451\System.Data.Common.dll</HintPath>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web">
       <Name>System.Web</Name>
@@ -166,7 +151,6 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="Extensions.snk" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -194,6 +178,20 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MySqlConnector">
+      <Version>0.68.0</Version>
+    </PackageReference>
+    <PackageReference Include="System.Memory">
+      <Version>4.5.4</Version>
+    </PackageReference>
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe">
+      <Version>4.7.1</Version>
+    </PackageReference>
+    <PackageReference Include="System.Threading.Tasks.Extensions">
+      <Version>4.5.4</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Extension/MySql.csproj
+++ b/Extension/MySql.csproj
@@ -100,15 +100,15 @@
   <ItemGroup>
     <Reference Include="PhpNetClassLibrary, Version=4.0.0.0, Culture=neutral, PublicKeyToken=4af37afe3cde05fb, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetClassLibrary.dll</HintPath>
+      <HintPath>..\..\..\snap\ExternalAssemblies\Phalanger\PhpNetClassLibrary.dll</HintPath>
     </Reference>
     <Reference Include="PhpNetCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0a8e8c4c76728c71, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetCore.dll</HintPath>
+      <HintPath>..\..\..\snap\ExternalAssemblies\Phalanger\PhpNetCore.dll</HintPath>
     </Reference>
     <Reference Include="PhpNetCore.Parsers, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0a8e8c4c76728c71, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetCore.Parsers.dll</HintPath>
+      <HintPath>..\..\..\snap\ExternalAssemblies\Phalanger\PhpNetCore.Parsers.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <Name>System</Name>

--- a/Extension/MySql.csproj
+++ b/Extension/MySql.csproj
@@ -116,9 +116,6 @@
     <Reference Include="System.Data">
       <Name>System.Data</Name>
     </Reference>
-    <Reference Include="System.Data.Common, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Data.Common.4.3.0\lib\net451\System.Data.Common.dll</HintPath>
-    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web">
@@ -141,6 +138,7 @@
     <Compile Include="MySql.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="MySqlExtensions.cs" />
     <Compile Include="PhpMyDbConnection.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Extension/MySqlExtensions.cs
+++ b/Extension/MySqlExtensions.cs
@@ -1,0 +1,64 @@
+﻿using MySql.Data.MySqlClient;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PHP.Library.Data
+{
+    internal static class MySqlExtensions
+    {
+        public static bool IsUnsigned(this MySqlDbColumn col)
+        {
+            switch (col.ProviderType)
+            {
+                case MySqlDbType.UByte:
+                case MySqlDbType.UInt16:
+                case MySqlDbType.UInt24:
+                case MySqlDbType.UInt32:
+                case MySqlDbType.UInt64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsBlob(this MySqlDbColumn col)
+        {
+            switch (col.ProviderType)
+            {
+                case MySqlDbType.Blob:
+                case MySqlDbType.LongBlob:
+                case MySqlDbType.MediumBlob:
+                case MySqlDbType.TinyBlob:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public static bool IsNumeric(this MySqlDbColumn col)
+        {
+            switch (col.ProviderType)
+            {
+                case MySqlDbType.Int16:
+                case MySqlDbType.Int24:
+                case MySqlDbType.Int32:
+                case MySqlDbType.Int64:
+                case MySqlDbType.Double:
+                case MySqlDbType.Year:
+                case MySqlDbType.Timestamp:
+                case MySqlDbType.Decimal:
+                case MySqlDbType.Float:
+                case MySqlDbType.UByte:
+                case MySqlDbType.UInt16:
+                case MySqlDbType.UInt24:
+                case MySqlDbType.UInt32:
+                case MySqlDbType.UInt64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }

--- a/Extension/MySqlExtensions.cs
+++ b/Extension/MySqlExtensions.cs
@@ -62,3 +62,4 @@ namespace PHP.Library.Data
             }
         }
     }
+}

--- a/Extension/PhpMyDbConnection.cs
+++ b/Extension/PhpMyDbConnection.cs
@@ -69,18 +69,9 @@ namespace PHP.Library.Data
 	    {
 	        get
 	        {
-	            if (_mySqlConnection == null) 
-                {
-                    _mySqlConnection = connection as MySqlConnection;
-                    if (_mySqlConnection == null) 
-                    {
-                        _mySqlConnection = MySqlDataReaderHelper.GetProperty<MySqlConnection>(connection, "InnerConnection");
-                    }
-                }
-                return _mySqlConnection;
-	        }
+				return connection as MySqlConnection;
+			}
 	    }
-	    private MySqlConnection _mySqlConnection;
 
 	    /// <summary>
         /// Override the connection to use a shared connection

--- a/Extension/app.config
+++ b/Extension/app.config
@@ -20,8 +20,8 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Data.Common" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>

--- a/Extension/app.config
+++ b/Extension/app.config
@@ -1,23 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Data.Common" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>

--- a/Extension/packages.config
+++ b/Extension/packages.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MySqlConnector" version="0.66.0" targetFramework="net461" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net461" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net461" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
-</packages>

--- a/MigrationBackup/552a9eda/MySql/MySql.csproj
+++ b/MigrationBackup/552a9eda/MySql/MySql.csproj
@@ -1,0 +1,217 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <PropertyGroup>
+    <ProjectType>Local</ProjectType>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{D3C83649-9B7F-46BF-9984-FFDE06C7C2DD}</ProjectGuid>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ApplicationIcon>
+    </ApplicationIcon>
+    <AssemblyKeyContainerName>
+    </AssemblyKeyContainerName>
+    <AssemblyName>PhpNetMySql</AssemblyName>
+    <AssemblyOriginatorKeyFile>Extensions.snk</AssemblyOriginatorKeyFile>
+    <DefaultClientScript>JScript</DefaultClientScript>
+    <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
+    <DefaultTargetSchema>IE50</DefaultTargetSchema>
+    <DelaySign>false</DelaySign>
+    <OutputType>Library</OutputType>
+    <RootNamespace>MySQL</RootNamespace>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <StartupObject>
+    </StartupObject>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <SignAssembly>true</SignAssembly>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>bin\Debug\</OutputPath>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <BaseAddress>285212672</BaseAddress>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <ConfigurationOverrideFile>
+    </ConfigurationOverrideFile>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DocumentationFile>bin\Debug\PhpNetMySql.xml</DocumentationFile>
+    <DebugSymbols>true</DebugSymbols>
+    <FileAlignment>4096</FileAlignment>
+    <NoStdLib>false</NoStdLib>
+    <NoWarn>1591</NoWarn>
+    <Optimize>false</Optimize>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <RemoveIntegerChecks>false</RemoveIntegerChecks>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningLevel>4</WarningLevel>
+    <DebugType>full</DebugType>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>bin\Release\</OutputPath>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+    <BaseAddress>437256192</BaseAddress>
+    <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
+    <ConfigurationOverrideFile>
+    </ConfigurationOverrideFile>
+    <DefineConstants>TRACE</DefineConstants>
+    <DocumentationFile>bin\Release\PhpNetMySql.xml</DocumentationFile>
+    <DebugSymbols>false</DebugSymbols>
+    <FileAlignment>4096</FileAlignment>
+    <NoStdLib>false</NoStdLib>
+    <NoWarn>
+    </NoWarn>
+    <Optimize>true</Optimize>
+    <RegisterForComInterop>false</RegisterForComInterop>
+    <RemoveIntegerChecks>false</RemoveIntegerChecks>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningLevel>4</WarningLevel>
+    <DebugType>none</DebugType>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="MySqlConnector, Version=0.66.0.0, Culture=neutral, PublicKeyToken=d33d3e53aa5f8c92, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySqlConnector.0.66.0\lib\net461\MySqlConnector.dll</HintPath>
+    </Reference>
+    <Reference Include="PhpNetClassLibrary, Version=4.0.0.0, Culture=neutral, PublicKeyToken=4af37afe3cde05fb, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetClassLibrary.dll</HintPath>
+    </Reference>
+    <Reference Include="PhpNetCore, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0a8e8c4c76728c71, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetCore.dll</HintPath>
+    </Reference>
+    <Reference Include="PhpNetCore.Parsers, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0a8e8c4c76728c71, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\amain\ExternalAssemblies\Phalanger\PhpNetCore.Parsers.dll</HintPath>
+    </Reference>
+    <Reference Include="System">
+      <Name>System</Name>
+    </Reference>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data">
+      <Name>System.Data</Name>
+    </Reference>
+    <Reference Include="System.Data.Common, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.Common.4.3.0\lib\net451\System.Data.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Web">
+      <Name>System.Web</Name>
+    </Reference>
+    <Reference Include="System.Xml">
+      <Name>System.XML</Name>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="Configuration.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="LibraryDescriptor.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="MySql.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="PhpMyDbConnection.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="PhpMyDbResult.cs">
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="Extensions.snk" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.2.0">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 2.0 %28x86%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.0">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.0 %28x86%29</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+    <PostBuildEvent>if $(ConfigurationName) == Release (
+      xcopy /q /y "$(TargetDir)MySqlConnector.dll" "$(SolutionDir)Deployment\Bin" 1&gt;nul
+      xcopy /q /y "$(TargetDir)$(TargetName).dll" "$(SolutionDir)Deployment\Bin" 1&gt;nul
+      xcopy /q /y "$(TargetDir)$(TargetName).xml" "$(SolutionDir)Deployment\Bin" 1&gt;nul
+)
+
+      if $(ConfigurationName) == Debug (
+      xcopy /q /y "$(TargetDir)MySqlConnector.dll" "$(SolutionDir)Deployment\Debug" 1&gt;nul
+      xcopy /q /y "$(TargetDir)$(TargetName).dll" "$(SolutionDir)Deployment\Debug" 1&gt;nul
+      xcopy /q /y "$(TargetDir)$(TargetName).xml" "$(SolutionDir)Deployment\Debug" 1&gt;nul
+)</PostBuildEvent>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
- needs to target framework `net472`
- uses `DbColumn` from schema instead of internal ColFlags (which are not available)
- removed reflection and runtime hacks
- migrated to `PackageReference` instead of `packages.json`